### PR TITLE
Include custom stylesheet in HTML when given as a parameter.

### DIFF
--- a/app/controllers/quby/answers_controller.rb
+++ b/app/controllers/quby/answers_controller.rb
@@ -16,6 +16,7 @@ module Quby
 
     before_filter :remember_token_in_session
     before_filter :remember_return_url_in_session
+    before_filter :remember_custom_stylesheet
     before_filter :verify_token, :only => [:show, :edit, :update, :print]
     before_filter :verify_hmac, :only => [:edit, :print]
 
@@ -221,6 +222,10 @@ module Quby
       end
 
       @display_mode = "paged" if @display_mode.blank?
+    end
+
+    def remember_custom_stylesheet
+      @custom_stylesheet = params[:stylesheet]
     end
 
     def redirect_to_roqua(options = {})

--- a/app/views/layouts/quby/application.html.haml
+++ b/app/views/layouts/quby/application.html.haml
@@ -8,6 +8,8 @@
     = stylesheet_link_tag "quby/print", :media => "print"
     /[if IE]
       = stylesheet_link_tag 'quby/ie.css', :media => 'screen, projection'
+    - if @custom_stylesheet.present?
+      = stylesheet_link_tag @custom_stylesheet, :media => 'screen, projection'
     = javascript_include_tag "quby/application.js"
     = javascript_include_tag "quby/jquery.ba-hashchange.min.js"
     = javascript_include_tag "quby/printer"


### PR DESCRIPTION
This enables upstream to customize the looks of questionnaires based on information that does not belong to Quby's domain.
