### PR TITLE
Less airbrake exceptions from quby-admin.

### DIFF
--- a/app/assets/stylesheets/quby/screen.css.scss
+++ b/app/assets/stylesheets/quby/screen.css.scss
@@ -206,3 +206,8 @@ input:placeholder, textarea:placeholder {
         cursor: pointer;
     }
 }
+
+.error .stacktrace {
+  color: #777;
+  white-space: pre-line;
+}

--- a/app/models/quby/questionnaire.rb
+++ b/app/models/quby/questionnaire.rb
@@ -5,7 +5,6 @@ module Quby
     extend  ActiveModel::Naming
     include ActiveModel::Validations
 
-    class RecordNotFound < StandardError; end
     class ValidationError < StandardError; end
     class UnknownInputKey < ValidationError; end
 

--- a/app/views/errors/questionnaire_not_found.html.haml
+++ b/app/views/errors/questionnaire_not_found.html.haml
@@ -1,0 +1,5 @@
+.panel
+  .toolbar
+    Questionnaire niet gevonden.
+  :markdown
+    De questionnaire met key: #{@error} bestaat niet in dit systeem.

--- a/app/views/quby/answers/paged/_item.html.haml
+++ b/app/views/quby/answers/paged/_item.html.haml
@@ -54,9 +54,9 @@
       - when :select
         = render :partial => "quby/answers/paged/item_question_select", :locals => {:question => item, :subquestion => subquestion, :disabled => disabled}
       - else
-        - raise "Unknown question type #{item.type} for question #{item.key}"
+        - raise Quby::Questionnaire::ValidationError, "Unknown question type #{item.type} for question #{item.key}"
     - when "Quby::Items::Table"
       = render :partial => "quby/answers/table/table", :locals => {:table => item}
     - else
-      - raise "Unknown item type #{item.class.name} for question #{item.key}"
+      - raise Quby::Questionnaire::ValidationError, "Unknown item type #{item.class.name} for question #{item.key}"
 / End _item.html.haml

--- a/app/views/quby/answers/show_questionnaire_errors.html.haml
+++ b/app/views/quby/answers/show_questionnaire_errors.html.haml
@@ -1,10 +1,15 @@
 - if Quby.show_exceptions
   .flash
     .error
-      \#{@questionnaire.errors.size} errors
-      %ul
-        - @questionnaire.errors.full_messages.each do |msg|
-          %li= msg
+      - if @questionnaire && @questionnaire.errors.size > 0
+        \#{@questionnaire.errors.size} errors
+        %ul
+          - @questionnaire.errors.full_messages.each do |msg|
+            %li= msg
+      - if @error
+        %p= @error.message
+        %br
+        %p.stacktrace= @error.backtrace[0..15].join("\n")
 - else
   .flash
     .error

--- a/app/views/quby/answers/table/_item_option_radio.html.haml
+++ b/app/views/quby/answers/table/_item_option_radio.html.haml
@@ -1,4 +1,5 @@
 - available_width = question.presentation == :horizontal ? 100 : 66
+
 - if opt.inner_title
   %td.option{ :style => "width:#{available_width/(table.columns)}%"}= opt.description
 - else

--- a/lib/quby.rb
+++ b/lib/quby.rb
@@ -1,6 +1,7 @@
 require "quby/engine"
 
 module Quby
+
   class << self
     def questionnaires_path
       @questionnaires_path

--- a/spec/views/quby/answers/show_questionnaire_errors_spec.rb
+++ b/spec/views/quby/answers/show_questionnaire_errors_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require 'English'
+
+describe "quby/answers/show_questionnaire_errors" do
+  before do
+    Quby.show_exceptions = true
+  end
+  let(:questionnaire) do
+    q = Quby::Questionnaire.new('key')
+    q.errors.add(:definition, "all wrong")
+    q
+  end
+  it "displays errors in the questionnaire" do
+    assign(:questionnaire, questionnaire)
+    render
+
+    expect(rendered).to match /all wrong/
+  end
+
+  let(:error) { raise Quby::Questionnaire::ValidationError, 'totally wrong' rescue $ERROR_INFO }
+
+  it "displays errors passed on" do
+    assign(:error, error)
+    render
+
+    expect(rendered).to match /totally wrong/
+  end
+
+  it 'Shows a vague error message when Quby.show_exceptions = false' do
+    Quby.show_exceptions = false
+    render
+
+    expect(rendered).to match /Er zit een fout in de definitie van deze vragenlijst/
+  end
+
+end


### PR DESCRIPTION
Show 404 on questionnaire not found.
Show validationerrors to user without notifying airbrake when Quby.show_exeptions is set. 
Throwing validation exception in views
