### PR TITLE
Hack to skip inner_title in validation

### DIFF
--- a/app/models/quby/definition_validator.rb
+++ b/app/models/quby/definition_validator.rb
@@ -40,7 +40,8 @@ module Quby
           end
         end
         if question.type == :check_box
-          question.options.andand.each { |option| validate_key_format option.key }
+          question.options.andand.select { |option| not option.inner_title }
+                                 .each { |option| validate_key_format option.key }
         end
       end
     end

--- a/spec/models/quby/definition_validator_spec.rb
+++ b/spec/models/quby/definition_validator_spec.rb
@@ -76,6 +76,8 @@ module Quby
           question :v_4, type: :check_box do
             title "Testvraag met een check_box"
             option :v_q1, description: 'some_description'
+            inner_title 'blaat'
+            option :v_q2, description: 'more_description'
           end
         END
         DefinitionValidator.new(questionnaire, invalid_keys).validate.should be_false


### PR DESCRIPTION
hack to skip inner_title on questionnaire definition validation
