### PR TITLE
updated maruku, fixed maruku extension, fixed specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       haml
       jquery-rails (~> 2.2.1)
       json
-      maruku (= 0.6.1)
+      maruku (~> 0.7.2)
       opencpu (~> 0.7.4)
       rails (>= 3.2, < 5.0)
       ryansch-andand
@@ -165,8 +165,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    maruku (0.6.1)
-      syntax (>= 1.0.0)
+    maruku (0.7.2)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)
@@ -274,7 +273,6 @@ GEM
     susy (1.0.9)
       compass (>= 0.12.2)
       sass (>= 3.2.0)
-    syntax (1.2.0)
     teaspoon (0.7.9)
       railties (>= 3.2.5, < 5)
     therubyracer (0.12.1)

--- a/lib/quby/extensions/maruku_extensions.rb
+++ b/lib/quby/extensions/maruku_extensions.rb
@@ -9,9 +9,9 @@ TEXT_VAR = /(\{\{)(.+?)(\}\})/
 MaRuKu::In::Markdown.register_span_extension(chars: (RUBY_VERSION >= '1.9' ? '{' : 123), # ASCII ordinal of {
                                              regexp: TEXT_VAR,
                                              handler: lambda do |doc, src, con|
-                                                        m = src.read_regexp3(TEXT_VAR)
+                                                        m = src.read_regexp(TEXT_VAR)
                                                         var_name = m.captures.compact[1]
-                                                        string = "<span class='text_var' text_var='#{var_name}'>{{#{var_name}}}</span>"
+                                                        string = "<span class='text_var' text_var='#{var_name}'>{#{var_name}}</span>"
                                                         con.push doc.md_html(string)
                                                         # con.push doc.md_html("<p>raw html</p>")
                                                         true
@@ -23,7 +23,7 @@ LINK_URL = /(\~\~)(.+)(\~\~)(.+)(\~\~)/
 MaRuKu::In::Markdown.register_span_extension(chars: (RUBY_VERSION >= '1.9' ? '~' : 126), # ASCII ordinal of ~
                                              regexp: LINK_URL,
                                              handler: lambda do |doc, src, con|
-                                                        m = src.read_regexp3(LINK_URL)
+                                                        m = src.read_regexp(LINK_URL)
                                                         url = m.captures.compact[1]
                                                         link_body = m.captures.compact[3]
                                                         string = "<a href='#' onclick='modalFrame(\"#{url}\");'>#{link_body}</a>"

--- a/quby.gemspec
+++ b/quby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency "haml"
   s.add_dependency "sass-rails",    '>= 3.2', '< 5.0'
-  s.add_dependency "maruku",        '0.6.1'
+  s.add_dependency "maruku",        '~> 0.7.2'
   s.add_dependency "compass",       '~> 0.12'
   s.add_dependency "compass-rails"
   s.add_dependency "susy", "~> 1.0.rc"

--- a/spec/features/text_var_spec.rb
+++ b/spec/features/text_var_spec.rb
@@ -32,7 +32,7 @@ feature 'text_var replacement', js: true do
 
     visit_new_answer_for(questionnaire)
 
-    page.should have_content 'Probleemmiddel: {{middel}}'
+    page.should have_content 'Probleemmiddel: {middel}'
   end
 
 end

--- a/spec/quby/extensions/maruku_extensions_spec.rb
+++ b/spec/quby/extensions/maruku_extensions_spec.rb
@@ -5,17 +5,17 @@ class Maruku
 
   describe "link tag extenstion ~~url~~body~~" do
     it "converts ~~url~~body~~ into a modal frame link" do
-      Maruku.new("~~http://google.com~~google~~").to_html.should == "<p><a href='#' onclick='modalFrame(\"http://google.com\");'>google</a></p>"
+      Maruku.new("~~http://google.com~~google~~").to_html.strip.should == "<p><a href='#' onclick='modalFrame(\"http://google.com\");'>google</a></p>"
     end
   end
 
   describe "text variable extenstion {{text_var}}" do
     it "converts {{test}} into a text variable span" do
-      Maruku.new("{{test}}").to_html.should == "<p><span class='text_var' text_var='test'>{{test}}</span></p>"
+      Maruku.new("{{test}}").to_html.strip.should == "<p><span class='text_var' text_var='test'>{test}</span></p>"
     end
 
     it "properly converts 2 text tags next to each other" do
-      Maruku.new("{{test}} {{test2}}").to_html.should == "<p><span class='text_var' text_var='test'>{{test}}</span> <span class='text_var' text_var='test2'>{{test2}}</span></p>"
+      Maruku.new("{{test}} {{test2}}").to_html.strip.should == "<p><span class='text_var' text_var='test'>{test}</span> <span class='text_var' text_var='test2'>{test2}</span></p>"
     end
   end
 

--- a/spec/quby/questionnaires/entities/text_spec.rb
+++ b/spec/quby/questionnaires/entities/text_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 module Quby::Questionnaires::Entities
   describe Text do
     before(:all) do
-      @some_string = "I'm a string"
-      @markdown_result = "<p>I&#8217;m a string</p>"
+      @some_string = "I'm _a_ string"
+      @markdown_result = "<p>I’m <em>a</em> string</p>"
     end
 
     it "should be creatable from a string" do
@@ -14,7 +14,7 @@ module Quby::Questionnaires::Entities
     describe "#to_s" do
       it "should return the string the Text was initialized with" do
         text = Quby::Questionnaires::Entities::Text.new(@some_string)
-        text.to_s.should == @markdown_result
+        text.to_s.strip.should == @markdown_result
       end
     end
 


### PR DESCRIPTION
Note: Waar {{var}} eerst naar 

```
<span..>{{var}}</span>
```

ging, gaat hij nu naar 

```
<span..>{var}</span>
```

Omdat het anders 2x recursief vervangen wordt.
