### PR TITLE
maximum_checked_allowed and minimum_checked_required added to DSL

### DIFF
--- a/app/assets/javascripts/quby/answers/rest.js
+++ b/app/assets/javascripts/quby/answers/rest.js
@@ -114,6 +114,7 @@ function handleMaximumCheckedAllowed(element, max) {
   var item                 = $(element).closest('.item');
   var checkboxes           = item.find('input[type=checkbox]');
   var checked_checkboxes   = checkboxes.filter(':checked');
+  var unchecked_checkboxes = checkboxes.filter(':not(:checked)');
 
   if (checked_checkboxes.length >= max) {
     unchecked_checkboxes.attr('disabled', true);

--- a/app/assets/javascripts/quby/answers/rest.js
+++ b/app/assets/javascripts/quby/answers/rest.js
@@ -110,6 +110,19 @@ function handleDisableCheckboxSubQuestions(element){
     }
 }
 
+function handleMaximumCheckedAllowed(element, max) {
+  var item                 = $(element).closest('.item');
+  var checkboxes           = item.find('input[type=checkbox]');
+  var checked_checkboxes   = checkboxes.filter(':checked');
+
+  if (checked_checkboxes.length >= max) {
+    unchecked_checkboxes.attr('disabled', true);
+  }
+  else {
+    checkboxes.removeAttr('disabled');
+  }
+}
+
 function preventDefault(event){
     if (event.preventDefault) {
         event.preventDefault();

--- a/app/assets/javascripts/quby/answers/validation.js
+++ b/app/assets/javascripts/quby/answers/validation.js
@@ -149,6 +149,18 @@
                       pushFailVal(validation.type);
                   }
                   break;
+              case "maximum_checked_allowed":
+                  var checkboxes = panel.find('input[type=checkbox]:checked');
+                  if (checkboxes.length > validation.maximum_checked_value) {
+                      pushFailVal(validation.type);
+                  }
+                  break;
+              case "minimum_checked_required":
+                  var checkboxes = panel.find('input[type=checkbox]:checked');
+                  if (checkboxes.length < validation.minimum_checked_value) {
+                    pushFailVal(validation.type);
+                  }
+                  break;
               //These validations would only come into play if the javascript that makes it impossible
               //to check an invalid combination of checkboxes fails.
               case "too_many_checked":

--- a/app/assets/javascripts/quby/answers/validation.js
+++ b/app/assets/javascripts/quby/answers/validation.js
@@ -150,13 +150,13 @@
                   }
                   break;
               case "maximum_checked_allowed":
-                  var checkboxes = panel.find('input[type=checkbox]:checked');
+                  var checkboxes = question_item.find('input[type=checkbox]:checked');
                   if (checkboxes.length > validation.maximum_checked_value) {
                       pushFailVal(validation.type);
                   }
                   break;
               case "minimum_checked_required":
-                  var checkboxes = panel.find('input[type=checkbox]:checked');
+                  var checkboxes = question_item.find('input[type=checkbox]:checked');
                   if (checkboxes.length < validation.minimum_checked_value) {
                     pushFailVal(validation.type);
                   }

--- a/app/views/quby/v1/bulk/_item_question_check_box.html.haml
+++ b/app/views/quby/v1/bulk/_item_question_check_box.html.haml
@@ -17,14 +17,22 @@
       - cls << "show_values" if question.show_values_in_mode? :bulk
       .option{ :for => question.key, :class => cls}
         .radiocheckwrapper
+          - handlers = ''
           - if question.uncheck_all_option == opt.key
-            -attrs = {:onClick => "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', false); handleDisableCheckboxSubQuestions(this);", :class => subquestion ? "subinput" : ""}
+            - handlers = "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', false);"
           - elsif question.check_all_option == opt.key
-            -attrs = {:onClick => "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', true); handleDisableCheckboxSubQuestions(this);", :class => subquestion ? "subinput" : ""}
+            - handlers = "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', true);"
           - else
-            -attrs = {:onClick => "correctAllNothingCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}'); handleDisableCheckboxSubQuestions(this);", :class => subquestion ? "subinput" : ""}
-          -if disabled
-            -attrs[:disabled] = ""
+            - handlers = "correctAllNothingCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}');"
+          - handlers += " handleDisableCheckboxSubQuestions(this);",
+
+          - if question.maximum_checked_allowed
+            - handlers += " handleMaximumCheckedAllowed(this, #{question.maximum_checked_allowed});"
+
+          - attrs = {onClick: handlers, class: subquestion ? 'subinput' : ''}
+
+          - if disabled
+            - attrs[:disabled] = ""
           = check_box(:answer, "#{opt.key}", attrs)
         - if question.show_values_in_mode? :bulk
           .value= opt.value

--- a/app/views/quby/v1/bulk/_item_question_check_box.html.haml
+++ b/app/views/quby/v1/bulk/_item_question_check_box.html.haml
@@ -24,7 +24,7 @@
             - handlers = "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', true);"
           - else
             - handlers = "correctAllNothingCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}');"
-          - handlers += " handleDisableCheckboxSubQuestions(this);",
+          - handlers += " handleDisableCheckboxSubQuestions(this);"
 
           - if question.maximum_checked_allowed
             - handlers += " handleMaximumCheckedAllowed(this, #{question.maximum_checked_allowed});"

--- a/app/views/quby/v1/paged/_item_question_check_box.html.haml
+++ b/app/views/quby/v1/paged/_item_question_check_box.html.haml
@@ -21,13 +21,21 @@
         - next if( opt.hidden and not checked)
         .option{:for => question.key, :class => show_values ? "show_values" : nil}
           .radiocheckwrapper
-            - attrs =  {:class => subquestion ? "subinput" : ""}
+            - handlers = ''
             - if question.uncheck_all_option == opt.key
-              - attrs = {:onClick => "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', false); handleDisableCheckboxSubQuestions(this);", :class => subquestion ? "subinput" : ""}
+              - handlers = "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', false);"
             - elsif question.check_all_option == opt.key
-              - attrs = {:onClick => "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', true); handleDisableCheckboxSubQuestions(this);", :class => subquestion ? "subinput" : ""}
+              - handlers = "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', true);"
             - else
-              - attrs = {:onClick => "correctAllNothingCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}'); handleDisableCheckboxSubQuestions(this);", :class => subquestion ? "subinput" : ""}
+              - handlers = "correctAllNothingCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}');"
+
+            - handlers += ' handleDisableCheckboxSubQuestions(this);'
+
+            - if question.maximum_checked_allowed
+              - handlers += " handleMaximumCheckedAllowed(this, #{question.maximum_checked_allowed});"
+
+            - attrs =  {onClick: handlers, class: subquestion ? 'subinput' : ''}
+
             - if disabled
               - attrs[:disabled] = ""
             - attrs[:class] = question.type

--- a/app/views/quby/v1/paged/_item_question_check_box.html.haml
+++ b/app/views/quby/v1/paged/_item_question_check_box.html.haml
@@ -28,8 +28,7 @@
               - handlers = "setAllCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}', '#{question.key}', true);"
             - else
               - handlers = "correctAllNothingCheckboxes(this.checked, '#{question.check_all_option}', '#{question.uncheck_all_option}');"
-
-            - handlers += ' handleDisableCheckboxSubQuestions(this);'
+            - handlers += " handleDisableCheckboxSubQuestions(this);"
 
             - if question.maximum_checked_allowed
               - handlers += " handleMaximumCheckedAllowed(this, #{question.maximum_checked_allowed});"

--- a/app/views/quby/v1/shared/_validations.html.haml
+++ b/app/views/quby/v1/shared/_validations.html.haml
@@ -2,10 +2,10 @@
   - exp_classes = ["error", validation[:type]]
   - valtypes = answer.errors[question.key].collect{|e| e[:valtype]}
   - unless valtypes.include?(validation[:type])
-    - exp_classes << "hidden" 
+    - exp_classes << "hidden"
   - case validation[:type]
   - when :maximum
-    %div{:class => exp_classes}= validation[:explanation] || "Uw antwoord moet een getal kleiner dan of gelijk aan #{validation[:value]} zijn." 
+    %div{:class => exp_classes}= validation[:explanation] || "Uw antwoord moet een getal kleiner dan of gelijk aan #{validation[:value]} zijn."
   - when :minimum
     %div{:class => exp_classes}= validation[:explanation] || "Uw antwoord moet een getal groter dan of gelijk aan #{validation[:value]} zijn."
   - when :requires_answer
@@ -20,6 +20,10 @@
     %div{:class => exp_classes}= validation[:explanation] || "U heeft te veel opties gekozen."
   - when :not_all_checked
     %div{:class => exp_classes}= validation[:explanation] || "U heeft te weinig opties gekozen."
+  - when :maximum_checked_allowed
+    %div{:class => exp_classes}= validation[:explanation] || "U mag maximaal #{validation[:maximum_checked_value]} opties kiezen."
+  - when :minimum_checked_required
+    %div{:class => exp_classes}= validation[:explanation] || "U moet minstens #{validation[:minimum_checked_value]} opties kiezen."
   - when :answer_group_minimum
     %div{:class => exp_classes}= validation[:explanation] || "Beantwoord minstens #{validation[:value]} van deze vragen"
   - when :answer_group_maximum
@@ -28,4 +32,3 @@
     %strong
       Error: unknown validation type
       = validation[:type]
-      

--- a/lib/quby/answers/services/answer_validator.rb
+++ b/lib/quby/answers/services/answer_validator.rb
@@ -48,6 +48,10 @@ module Quby
                   validate_too_many_checked(question, validation, value)
                 when :not_all_checked
                   validate_not_all_checked(question, validation, value)
+                when :maximum_checked_allowed
+                  validate_maximum_checked_allowed(question, validation, value)
+                when :minimum_checked_required
+                  validate_minimum_checked_required(question, validation, value)
                 when :answer_group_minimum
                   validate_answer_group_minimum(question, validation, value)
                 when :answer_group_maximum
@@ -115,6 +119,18 @@ module Quby
           if answer.send(question.check_all_option) == 1 and
               value.values.reduce(:+) < value.length - (question.uncheck_all_option ? 1 : 0)
             answer.send(:add_error, question, :not_all_checked, validation[:message] || "Invalid combination of options.")
+          end
+        end
+
+        def validate_maximum_checked_allowed(question, validation, value)
+          if value.values.reduce(:+) > question.maximum_checked_allowed.to_i
+            answer.send(:add_error, question, :maximum_checked_allowed, validation[:message] || "Too many options checked.")
+          end
+        end
+
+        def validate_minimum_checked_required(question, validation, value)
+          if value.values.reduce(:+) < question.minimum_checked_required.to_i
+            answer.send(:add_error, question, :minimum_checked_required, validation[:message] || "Not enough options checked.")
           end
         end
 

--- a/lib/quby/questionnaires/entities/questions/checkbox_question.rb
+++ b/lib/quby/questionnaires/entities/questions/checkbox_question.rb
@@ -37,13 +37,13 @@ module Quby
 
             if @maximum_checked_allowed
               @validations << {type: :maximum_checked_allowed,
-                               maximum_checked_key: @maximum_checked_allowed,
+                               maximum_checked_value: @maximum_checked_allowed,
                                explanation: options[:error_explanation]}
             end
 
             if @minimum_checked_required
               @validations << {type: :minimum_checked_required,
-                               minimum_checked_key: @minimum_checked_required,
+                               minimum_checked_value: @minimum_checked_required,
                                explanation: options[:error_explanation]}
             end
           end

--- a/lib/quby/questionnaires/entities/questions/checkbox_question.rb
+++ b/lib/quby/questionnaires/entities/questions/checkbox_question.rb
@@ -5,22 +5,45 @@ module Quby
         class CheckboxQuestion < Question
           # checkbox option that checks all other options on check
           attr_accessor :check_all_option
+
           # checkbox option that unchecks all other options on check
           attr_accessor :uncheck_all_option
+
+          # checkbox option that allows to select a maximum amount of checkboxes
+          attr_accessor :maximum_checked_allowed
+
+          # checkbox option that forces to select a minimum amount of checkboxes
+          attr_accessor :minimum_checked_required
 
           def initialize(key, options = {})
             super
 
-            @check_all_option = options[:check_all_option]
-            @uncheck_all_option = options[:uncheck_all_option]
+            @check_all_option         = options[:check_all_option]
+            @uncheck_all_option       = options[:uncheck_all_option]
+            @maximum_checked_allowed  = options[:maximum_checked_allowed]
+            @minimum_checked_required = options[:minimum_checked_required]
 
             if @check_all_option
-              @validations << {type: :not_all_checked, check_all_key: @check_all_option,
+              @validations << {type: :not_all_checked,
+                               check_all_key: @check_all_option,
                                explanation: options[:error_explanation]}
             end
 
             if @uncheck_all_option
-              @validations << {type: :too_many_checked, uncheck_all_key: @uncheck_all_option,
+              @validations << {type: :too_many_checked,
+                               uncheck_all_key: @uncheck_all_option,
+                               explanation: options[:error_explanation]}
+            end
+
+            if @maximum_checked_allowed
+              @validations << {type: :maximum_checked_allowed,
+                               maximum_checked_key: @maximum_checked_allowed,
+                               explanation: options[:error_explanation]}
+            end
+
+            if @minimum_checked_required
+              @validations << {type: :minimum_checked_required,
+                               minimum_checked_key: @minimum_checked_required,
                                explanation: options[:error_explanation]}
             end
           end

--- a/spec/features/question_validations/check_box_question_spec.rb
+++ b/spec/features/question_validations/check_box_question_spec.rb
@@ -111,6 +111,50 @@ shared_examples 'validations on checkbox questions' do
     end
   end
 
+  context 'maximum_checked_allowed' do
+    let(:questionnaire) do
+      inject_questionnaire 'test', <<-END
+        question :v_check_box, type: :check_box, maximum_checked_allowed: 2 do
+          title "Pick max two"
+          option :v_ck_a1, value: 1, description: 'Unicorns'
+          option :v_ck_a2, value: 2, description: 'Rainbows'
+          option :v_ck_a3, value: 3, description: 'Wortels'
+        end
+      END
+    end
+
+    scenario 'is valid when 1 or 2 are checked' do
+      next if validation_run_location == :client_side
+      check_option 'v_ck_a1'
+      check_option 'v_ck_a2'
+      check_option 'v_ck_a3'
+      run_validations
+      expect_error_on 'v_check_box', 'maximum_checked_allowed'
+    end
+  end
+
+  context 'minimum_checked_required' do
+    let(:questionnaire) do
+      inject_questionnaire 'test', <<-END
+        question :v_check_box, type: :check_box, minimum_checked_required: 2 do
+          title "Pick max two"
+          option :v_ck_a1, value: 1, description: 'Unicorns'
+          option :v_ck_a2, value: 2, description: 'Rainbows'
+          option :v_ck_a3, value: 3, description: 'Wortels'
+        end
+      END
+    end
+
+    scenario 'is valid when 2 or 3 are checked' do
+      next if validation_run_location == :client_side
+      check_option 'v_ck_a1'
+      uncheck_option 'v_ck_a2'
+      uncheck_option 'v_ck_a3'
+      run_validations
+      expect_error_on 'v_check_box', 'minimum_checked_required'
+    end
+  end
+
   context 'question groups' do
     let(:questionnaire) do
       inject_questionnaire "test", <<-END

--- a/spec/features/question_validations/check_box_question_spec.rb
+++ b/spec/features/question_validations/check_box_question_spec.rb
@@ -133,7 +133,7 @@ shared_examples 'validations on checkbox questions' do
     end
 
     scenario 'is valid when 2 options are checked' do
-      next if validation_run_location == :client_side
+      next if validation_run_locationce == :client_side
       check_option 'v_ck_a1'
       check_option 'v_ck_a2'
       uncheck_option 'v_ck_a3'

--- a/spec/features/question_validations/check_box_question_spec.rb
+++ b/spec/features/question_validations/check_box_question_spec.rb
@@ -123,13 +123,22 @@ shared_examples 'validations on checkbox questions' do
       END
     end
 
-    scenario 'is valid when 1 or 2 are checked' do
+    scenario 'is invalid when 3 options are checked' do
       next if validation_run_location == :client_side
       check_option 'v_ck_a1'
       check_option 'v_ck_a2'
       check_option 'v_ck_a3'
       run_validations
       expect_error_on 'v_check_box', 'maximum_checked_allowed'
+    end
+
+    scenario 'is valid when 2 options are checked' do
+      next if validation_run_location == :client_side
+      check_option 'v_ck_a1'
+      check_option 'v_ck_a2'
+      uncheck_option 'v_ck_a3'
+      run_validations
+      expect_no_errors
     end
   end
 
@@ -145,13 +154,22 @@ shared_examples 'validations on checkbox questions' do
       END
     end
 
-    scenario 'is valid when 2 or 3 are checked' do
+    scenario 'is invalid when 1 is checked' do
       next if validation_run_location == :client_side
       check_option 'v_ck_a1'
       uncheck_option 'v_ck_a2'
       uncheck_option 'v_ck_a3'
       run_validations
       expect_error_on 'v_check_box', 'minimum_checked_required'
+    end
+
+    scenario 'is valid when 2 options are checked' do
+      next if validation_run_location == :client_side
+      check_option 'v_ck_a1'
+      check_option 'v_ck_a2'
+      uncheck_option 'v_ck_a3'
+      run_validations
+      expect_no_errors
     end
   end
 

--- a/spec/features/question_validations/check_box_question_spec.rb
+++ b/spec/features/question_validations/check_box_question_spec.rb
@@ -133,7 +133,7 @@ shared_examples 'validations on checkbox questions' do
     end
 
     scenario 'is valid when 2 options are checked' do
-      next if validation_run_locationce == :client_side
+      next if validation_run_location == :client_side
       check_option 'v_ck_a1'
       check_option 'v_ck_a2'
       uncheck_option 'v_ck_a3'


### PR DESCRIPTION
- Validation fails when set to `maximum_checked_allowed` and amount of answers exceeds the value.
- Validation fails when set to `minimum_checked_required` and amount of answers does not meet the minimum value.



    question :v_1, :type => :check_box, :maximum_checked_allowed => 3, :minimum_checked_required => 1 do
      option :v_1_a1
      option :v_1_a2
      option :v_1_a3
      option :v_1_a4
    end