### PR TITLE
rowspan at least 1

### DIFF
--- a/app/views/quby/v1/table/_table.html.haml
+++ b/app/views/quby/v1/table/_table.html.haml
@@ -64,7 +64,7 @@
         - cyclei = 1 if ros_cycle == "dark"
         - if question and question.presentation != :horizontal
           - unless same_question
-            - rowspan = (question.options.length.to_f/table.columns).ceil
+            - rowspan = [(question.options.length.to_f/table.columns).ceil, 1].max
             - rowspan = 1 if question.type == :select
             - title_insert = nil
             - subq = question.options.last.andand.questions.andand.first


### PR DESCRIPTION
Als de rowspan 0 is vindt firefox dat ie over de hele lengte van de table moet lopen, daarom nu minimaal 1