### PR TITLE
bigger grid-padding

### DIFF
--- a/app/assets/stylesheets/quby/paged/mobile.css.scss
+++ b/app/assets/stylesheets/quby/paged/mobile.css.scss
@@ -1,5 +1,5 @@
 @mixin paged-mobile($width, $columns) {
-  $grid-padding: 10px;
+  $grid-padding: 20px;
   $label-columns: $columns / 3;
   $field-columns: $columns - $label-columns;
 


### PR DESCRIPTION
Grid-padding aangepast zodat er ook op safari mobile genoeg ruimte is voor het tekst veld. Dit heeft geen desastreuze gevolgen voor andere input velden.