### PR TITLE
Fix saving clashing subquestions by removing unused code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ spec/dummy/tmp/
 spec/internal/db/*.sqlite3
 spec/internal/log/*.log
 spec/internal/tmp/
+spec/internal/screenshot*
 .ruby-version
 .ruby-gemset
 .byebug-history

--- a/lib/quby/questionnaires/entities/questionnaire.rb
+++ b/lib/quby/questionnaires/entities/questionnaire.rb
@@ -323,15 +323,6 @@ module Quby
                 # question.type == :integer
                 # question.type == :float
 
-                if [:radio, :scale, :select].include? question.type # getters for individual question options
-                  question.options.each do |opt|
-                    define_method("#{question.key}_#{opt.key}") do
-                      self.value ||= Hash.new
-                      self.value[question.key.to_s] == opt.key.to_s
-                    end
-                  end
-                end
-
                 define_method(question.key) do
                   self.value ||= Hash.new
                   self.value[question.key.to_s]

--- a/spec/features/save_subquestion_clash_spec.rb
+++ b/spec/features/save_subquestion_clash_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+feature 'saving a question which key clashes with its parent option', js: true do
+  let(:questionnaire) { Quby.questionnaires.find('subquestion_key_clash') }
+  scenario 'saving should have the value end up in the raw params and in the value itself' do
+
+    answer = create_new_answer_for(questionnaire)
+    visit_new_answer_for(questionnaire, 'paged', answer)
+    choose 'answer_v_0_a1'
+    fill_in 'answer[v_0_a1]', with: 'clashing'
+    click_on 'Klaar'
+    page.should have_content("Bedankt voor het invullen van deze vragenlijst. Uw antwoorden zijn opgeslagen.")
+
+    answer = Quby.send(:answer_repo).send(:all_records, 'subquestion_key_clash').last
+
+    expect(answer.raw_params).to include("aborted" => false,
+                                         "v_0" => "a1",
+                                         "v_0_a1" => "clashing")
+    expect(answer.value).to eq("v_0" => "a1",
+                               'v_0_a1' => 'clashing')
+  end
+end

--- a/spec/fixtures/subquestion_key_clash.rb
+++ b/spec/fixtures/subquestion_key_clash.rb
@@ -1,0 +1,11 @@
+title 'Subquestion key clash questionnaire'
+
+panel do
+  question :v_0, :type => :radio do
+    title "A"
+    option :a1, description: 'Optie 1' do
+      question :v_0_a1, type: :textarea
+    end
+    option :a2, description: 'Optie 2'
+  end
+end

--- a/spec/quby/answers/services/updates_answers_spec.rb
+++ b/spec/quby/answers/services/updates_answers_spec.rb
@@ -21,6 +21,14 @@ module Quby::Answers::Services
         Quby.answers.reload(answer).attributes["random_key"].should_not == "value"
       end
 
+      context 'subquestion key clash' do
+        let(:answer) { Quby.answers.create!('subquestion_key_clash') }
+        it 'does not remove filtered values from raw_params' do
+          updates_answers.update('v_0' => 'a1', 'v_0_a1' => "value")
+          expect(Quby.answers.reload(answer).raw_params["v_0_a1"]).to eq("value")
+        end
+      end
+
       it 'validates the answer' do
         answer.should_receive :validate_answers
         updates_answers.update


### PR DESCRIPTION
Used to be used in https://github.com/roqua/quby_engine/commit/850f086b9120a36553f24c86a96a162a56e0486c#diff-a983bfc492e6d1982c673bc208afe459R167 but that was removed a long while ago. It was replaced by looking into the value hash instead of using the accessor methods: https://github.com/roqua/quby_engine/blob/master/lib/quby/answers/services/attribute_calculator.rb#L73

This code caused subquestions that have a key clash with their parent option to not be saved. We want to disallow those key clashes existing in general, but we also want to restore functionality first before going through every questionnaire with clashes and fixing them.