### PR TITLE
Fix for iPhone bug when selecting 0%

### DIFF
--- a/vendor/assets/javascripts/jquery.nouislider.with_roqua_modifications.js
+++ b/vendor/assets/javascripts/jquery.nouislider.with_roqua_modifications.js
@@ -585,7 +585,7 @@
 
 				// Don't perform placement if no handles are to be changed.
 				// Check if the lowest value is set to zero.
-				if ( l2 < 0 && !l1 && !handles[0].data('pct') ) {
+				if ( l2 < 0 && l1 === 0 && handles[0].data('pct') === 0 ) {
 					return;
 				}
 				// The highest value is limited to 100%.


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/297115/stories/135689105

Uiteraard dient er geen `!` check gebruikt te worden als het gaat om getallen, undefined is ook gewoon `false` namelijk.

Deze pull request lost de bug op, maar wat mij betreft mag deze hele lap code wel weg:
https://github.com/roqua/quby_engine/blob/51be6c8743a2e337cf2d04ed544dd69109306121/vendor/assets/javascripts/jquery.nouislider.with_roqua_modifications.js#L586-L594

Zie niet direct de toegevoegde waarde.