### PR TITLE
Fix for the slider when exactly 0.00 % is selected

### DIFF
--- a/vendor/assets/javascripts/jquery.nouislider.with_roqua_modifications.js
+++ b/vendor/assets/javascripts/jquery.nouislider.with_roqua_modifications.js
@@ -479,7 +479,7 @@
 			// Stop handling this call if the handle can't move past another.
 			// Return an array containing the hit limit, so the caller can
 			// provide feedback. ( block callback ).
-			if ( to === handle.data('pct') ) {
+			if ( handles.length > 1 && to === handle.data('pct') ) {
 				return [!lower ? false : lower, upper === 100 ? false : upper];
 			}
 


### PR DESCRIPTION
**Het probleem**
Het probleem is dat de value van de input die bij de slider hoort niet gezet wordt als er geklikt wordt op een plek die precies op 0.00 % uitkomt. Bij bijvoorbeeld 0.17 % is er niks aan de hand.

**De oplossing**
Het probleem lijkt ook veroorzaakt te worden doordat de slider intern altijd een (default) placement (data attribuut `pct`) heeft. In tegenstelling tot de implementatie van RoQua waarbij de slider eerst niet zichtbaar is. Ik dacht dat een mogelijke oplossing was om null waarde als placement te gebruiken bij het initialiseren, maar dan gaat de code van de slider kapot.

Aangezien de slider code nu een beetje misbruikt wordt voor een ander doeleinde zou een betere oplossing zou zijn om een eigen component te schrijven met overzichtelijke code.

Ik heb naar meerdere plekken gekeken om het probleem met de huidige code om te lossen en de gekozen plek lijkt toch het meest logisch. Het gaat hier fout:
`to === handle.data('pct')`

Bij het initialiseren van de slider wordt de positie van de slider op 0 gezet (handle.data('pct')). Als de eerste klik op de slider dan ook precies 0 is, dan wordt hier een return gedaan in deze functie i.p.v. placeHandle aan te roepen. placeHandle zet ergens dieper weer de value van het bijbehorende input element.

Het lijkt dat de code vooral opgezet is voor sliders met meerdere handles, vandaar `handles.length > 1` toegevoegd als 'fix'.