### PR TITLE
Limit textarea input length

### DIFF
--- a/app/views/quby/v1/bulk/_item_question_textarea.html.haml
+++ b/app/views/quby/v1/bulk/_item_question_textarea.html.haml
@@ -6,4 +6,4 @@
       :markdown
         #{raw question.description}
   .fields{:id => question.html_id}
-    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => subquestion ? "subinput" : "", :disabled => disabled ? "" : nil, data: {"field-key" => question.key}
+    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => subquestion ? "subinput" : "", :disabled => disabled ? "" : nil, data: {"field-key" => question.key}, :maxlength => 2000

--- a/app/views/quby/v1/bulk/_item_question_textarea.html.haml
+++ b/app/views/quby/v1/bulk/_item_question_textarea.html.haml
@@ -6,4 +6,4 @@
       :markdown
         #{raw question.description}
   .fields{:id => question.html_id}
-    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => subquestion ? "subinput" : "", :disabled => disabled ? "" : nil, data: {"field-key" => question.key}, :maxlength => 2000
+    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => subquestion ? "subinput" : "", :disabled => disabled ? "" : nil, data: {"field-key" => question.key}, :maxlength => 5000

--- a/app/views/quby/v1/paged/_item_question_textarea.html.haml
+++ b/app/views/quby/v1/paged/_item_question_textarea.html.haml
@@ -7,4 +7,4 @@
   .fields{:id => question.html_id}
     - cls = [question.type]
     - cls << "subinput"  if subquestion
-    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols , :autocomplete => question.autocomplete, :class => cls, :disabled => disabled ? "" : nil, data: {"field-key" => question.key}
+    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols , :autocomplete => question.autocomplete, :class => cls, :disabled => disabled ? "" : nil, data: {"field-key" => question.key}, :maxlength => 2000

--- a/app/views/quby/v1/paged/_item_question_textarea.html.haml
+++ b/app/views/quby/v1/paged/_item_question_textarea.html.haml
@@ -7,4 +7,4 @@
   .fields{:id => question.html_id}
     - cls = [question.type]
     - cls << "subinput"  if subquestion
-    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols , :autocomplete => question.autocomplete, :class => cls, :disabled => disabled ? "" : nil, data: {"field-key" => question.key}, :maxlength => 2000
+    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols , :autocomplete => question.autocomplete, :class => cls, :disabled => disabled ? "" : nil, data: {"field-key" => question.key}, :maxlength => 5000

--- a/app/views/quby/v1/table/_item_question_textarea.html.haml
+++ b/app/views/quby/v1/table/_item_question_textarea.html.haml
@@ -4,5 +4,5 @@
 - itemkey = "item_#{question.key}"
 %td.item{:id => itemkey, :class => classes, :style => "width:#{available_width/(table.columns)}%", :rowspan => question.row_span, :colspan => question.col_span, :data => question.extra_data}
   .fields{:class => question.type, :id => question.html_id}
-    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => question.type, :data => {'field-key' => question.key}
+    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => question.type, :data => {'field-key' => question.key}, :maxlength => 2000
     = validations

--- a/app/views/quby/v1/table/_item_question_textarea.html.haml
+++ b/app/views/quby/v1/table/_item_question_textarea.html.haml
@@ -4,5 +4,5 @@
 - itemkey = "item_#{question.key}"
 %td.item{:id => itemkey, :class => classes, :style => "width:#{available_width/(table.columns)}%", :rowspan => question.row_span, :colspan => question.col_span, :data => question.extra_data}
   .fields{:class => question.type, :id => question.html_id}
-    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => question.type, :data => {'field-key' => question.key}, :maxlength => 2000
+    = text_area :answer, question.key, :rows => question.lines, :cols => question.cols, :autocomplete => question.autocomplete, :class => question.type, :data => {'field-key' => question.key}, :maxlength => 5000
     = validations


### PR DESCRIPTION
Set textarea maxlength to 2000 to prevent db errors.